### PR TITLE
Support for node and edges style hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,23 @@ let mut view = egui_graphs::GraphView::new(&mut graph)
 
 Hooks receive the current `Stroke` derived from the active egui theme, so your custom logic stays consistent with light/dark modes.
 
+#### Hooks vs. Custom Node / Edge Drawers (Summary)
+
+Use a stroke hook when you only need quick visual tweaks (color / width / alpha) based on interaction state or simple heuristics.
+Implement a custom `DisplayNode` / `DisplayEdge` when you need to change geometry (different shapes, icons, multiple layered outlines), custom hit‑testing, animations, or rich graph‑context dependent visuals.
+
+| Need | Hook | Custom Drawer |
+|------|------|---------------|
+| Adjust stroke color/width on select/hover | ✅ | ✅ |
+| Fade or highlight edges | ✅ | ✅ |
+| Different node shape (rect, hex, image, pie) | ❌ | ✅ |
+| Custom label placement / multiple labels | ❌ | ✅ |
+| Custom hit area / hit test logic | ❌ | ✅ |
+| Graph‑topology aware geometry (hub size, cluster halos) | Limited (planned metrics) | ✅ |
+| Minimal boilerplate | ✅ | ❌ |
+
+Rule of thumb: start with hooks; switch to a custom drawer if you find yourself wanting to modify anything beyond the single stroke per node/edge.
+
 ### Events
 
 Can be enabled with `events` feature. Events describe a change made in graph whether it changed zoom level or node dragging.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -84,6 +84,12 @@ mod drawers {
             let start = v.nodes;
             ui.label("N");
             ui.add(egui::Slider::new(&mut v.nodes, 1..=500));
+            if ui.small_button("-10").clicked() {
+                v.nodes = (v.nodes.saturating_sub(10)).max(1);
+            }
+            if ui.small_button("-1").clicked() {
+                v.nodes = (v.nodes.saturating_sub(1)).max(1);
+            }
             if ui.small_button("+1").clicked() {
                 v.nodes = (v.nodes + 1).min(500);
             }
@@ -97,6 +103,12 @@ mod drawers {
             let start = v.edges;
             ui.label("E");
             ui.add(egui::Slider::new(&mut v.edges, 0..=500));
+            if ui.small_button("-10").clicked() {
+                v.edges = v.edges.saturating_sub(10);
+            }
+            if ui.small_button("-1").clicked() {
+                v.edges = v.edges.saturating_sub(1);
+            }
             if ui.small_button("+1").clicked() {
                 v.edges = (v.edges + 1).min(500);
             }
@@ -136,10 +148,12 @@ pub struct DemoApp {
     event_publisher: Sender<Event>,
     #[cfg(feature = "events")]
     event_consumer: Receiver<Event>,
+    // Theme state: true = dark mode, false = light mode
+    dark_mode: bool,
 }
 
 impl DemoApp {
-    fn new(_: &CreationContext<'_>) -> Self {
+    fn new(cc: &CreationContext<'_>) -> Self {
         let settings_graph = settings::SettingsGraph::default();
         let mut g = generate_random_graph(settings_graph.count_node, settings_graph.count_edge);
         // Place nodes on a circle to avoid overlapping at start.
@@ -177,6 +191,7 @@ impl DemoApp {
             event_publisher,
             #[cfg(feature = "events")]
             event_consumer,
+            dark_mode: cc.egui_ctx.style().visuals.dark_mode,
         }
     }
 
@@ -481,7 +496,27 @@ impl DemoApp {
 
     fn ui_style(&mut self, ui: &mut Ui) {
         CollapsingHeader::new("Style").show(ui, |ui| {
-            ui.checkbox(&mut self.settings_style.labels_always, "labels_always");
+            ui.horizontal(|ui| {
+                let currently_dark = ui.ctx().style().visuals.dark_mode;
+                let icon = if currently_dark { "☀" } else { "🌙" };
+                let tip = if currently_dark {
+                    "Switch to light theme"
+                } else {
+                    "Switch to dark theme"
+                };
+                if ui.small_button(icon).on_hover_text(tip).clicked() {
+                    if currently_dark {
+                        ui.ctx().set_visuals(egui::Visuals::light());
+                    } else {
+                        ui.ctx().set_visuals(egui::Visuals::dark());
+                    }
+                    self.dark_mode = ui.ctx().style().visuals.dark_mode;
+                } else {
+                    self.dark_mode = currently_dark;
+                }
+                ui.separator();
+                ui.checkbox(&mut self.settings_style.labels_always, "labels_always");
+            });
         });
     }
 
@@ -521,7 +556,7 @@ impl DemoApp {
     }
 
     fn overlay_debug(&self, ctx: &egui::Context) {
-        use egui::{Area, Color32, Frame, RichText};
+        use egui::{Area, RichText};
         let text = {
             let fps_line = format!("FPS: {:.1}", self.fps);
             let n_line = format!("N: {}", self.g.node_count());
@@ -544,21 +579,18 @@ impl DemoApp {
             )
         };
 
+        let visuals = &ctx.style().visuals;
         Area::new(egui::Id::new("debug_overlay"))
             .movable(false)
             .interactable(false)
             .anchor(Align2::LEFT_TOP, [10.0, 10.0])
             .show(ctx, |ui| {
-                Frame::new().corner_radius(4.0).show(ui, |ui| {
-                    ui.set_min_width(170.0);
-                    ui.add_space(2.0);
-                    ui.label(
-                        RichText::new(text)
-                            .monospace()
-                            .color(Color32::WHITE)
-                            .size(14.0),
-                    );
-                });
+                ui.label(
+                    RichText::new(text)
+                        .monospace()
+                        .color(visuals.strong_text_color())
+                        .size(14.0),
+                );
             });
     }
 
@@ -640,7 +672,17 @@ impl App for DemoApp {
                 .with_fit_to_screen_enabled(self.settings_navigation.fit_to_screen_enabled)
                 .with_zoom_speed(self.settings_navigation.zoom_speed);
             let settings_style = &egui_graphs::SettingsStyle::new()
-                .with_labels_always(self.settings_style.labels_always);
+                .with_labels_always(self.settings_style.labels_always)
+                .with_edge_stroke_hook(|selected, _order, stroke, _style| {
+                    // Reduce alpha by half for non-selected edges to de-emphasize them.
+                    let mut s = stroke;
+                    if !selected {
+                        let c = s.color;
+                        let new_a = (c.a() as f32 * 0.5) as u8;
+                        s.color = egui::Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), new_a);
+                    }
+                    s
+                });
 
             let mut view = egui_graphs::GraphView::<
                 _,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,9 +5,9 @@
 //! Run with interaction events panel:
 //!   cargo run --example demo --features events
 
+use core::cmp::Ordering;
 use eframe::{run_native, App, CreationContext};
 use egui::{self, Align2, CollapsingHeader, Pos2, ScrollArea, Ui};
-use core::cmp::Ordering;
 use egui_graphs::{generate_random_graph, Graph, LayoutForceDirected, LayoutStateForceDirected};
 use petgraph::stable_graph::{DefaultIx, EdgeIndex, NodeIndex};
 use petgraph::Directed;
@@ -298,19 +298,27 @@ impl DemoApp {
             |dn, de| {
                 match dn.cmp(&0) {
                     Ordering::Greater => {
-                        for _ in 0..dn { self.add_random_node(); }
+                        for _ in 0..dn {
+                            self.add_random_node();
+                        }
                     }
                     Ordering::Less => {
-                        for _ in 0..(-dn) { self.remove_random_node(); }
+                        for _ in 0..(-dn) {
+                            self.remove_random_node();
+                        }
                     }
                     Ordering::Equal => {}
                 }
                 match de.cmp(&0) {
                     Ordering::Greater => {
-                        for _ in 0..de { self.add_random_edge(); }
+                        for _ in 0..de {
+                            self.add_random_edge();
+                        }
                     }
                     Ordering::Less => {
-                        for _ in 0..(-de) { self.remove_random_edge(); }
+                        for _ in 0..(-de) {
+                            self.remove_random_edge();
+                        }
                     }
                     Ordering::Equal => {}
                 }
@@ -668,12 +676,12 @@ impl App for DemoApp {
                 .with_zoom_speed(self.settings_navigation.zoom_speed);
             let settings_style = &egui_graphs::SettingsStyle::new()
                 .with_labels_always(self.settings_style.labels_always)
-        .with_edge_stroke_hook(|selected, _order, stroke, _style| {
+                .with_edge_stroke_hook(|selected, _order, stroke, _style| {
                     // Reduce alpha by half for non-selected edges to de-emphasize them.
                     let mut s = stroke;
                     if !selected {
                         let c = s.color;
-            let new_a = (f32::from(c.a()) * 0.5) as u8;
+                        let new_a = (f32::from(c.a()) * 0.5) as u8;
                         s.color = egui::Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), new_a);
                     }
                     s

--- a/examples/flex_nodes.rs
+++ b/examples/flex_nodes.rs
@@ -196,7 +196,7 @@ mod node {
         }
 
         fn update(&mut self, state: &NodeProps<N>) {
-            self.label = state.label.clone();
+            self.label.clone_from(&state.label);
             self.loc = state.location();
         }
     }

--- a/examples/label_change.rs
+++ b/examples/label_change.rs
@@ -50,7 +50,7 @@ impl LabelChangeApp {
                 },
             );
             if ui.button("reset").clicked() {
-                self.reset(ui)
+                self.reset(ui);
             }
         });
         CentralPanel::default().show(ctx, |ui| {

--- a/src/draw/displays_default/edge.rs
+++ b/src/draw/displays_default/edge.rs
@@ -78,7 +78,7 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
         let color = style.fg_stroke.color;
         let base_stroke = Stroke::new(self.width, color);
         let stroke = if let Some(hook) = &ctx.style.edge_stroke_hook {
-            let style_ref: &egui::Style = &*ctx.ctx.style();
+            let style_ref: &egui::Style = &ctx.ctx.style();
             (hook)(self.selected, self.order, base_stroke, style_ref)
         } else {
             base_stroke

--- a/src/draw/displays_default/edge.rs
+++ b/src/draw/displays_default/edge.rs
@@ -76,7 +76,13 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType, D: DisplayNode<N, E, Ty, I
             ctx.ctx.style().visuals.widgets.inactive
         };
         let color = style.fg_stroke.color;
-        let stroke = Stroke::new(self.width, color);
+        let base_stroke = Stroke::new(self.width, color);
+        let stroke = if let Some(hook) = &ctx.style.edge_stroke_hook {
+            let style_ref: &egui::Style = &*ctx.ctx.style();
+            (hook)(self.selected, self.order, base_stroke, style_ref)
+        } else {
+            base_stroke
+        };
 
         if start.id() == end.id() {
             // draw loop
@@ -228,7 +234,8 @@ impl DefaultEdgeShape {
     ) -> bool {
         let node_size = node_size(node, Vec2::new(-1., 0.));
 
-        let shape = EdgeShapeBuilder::new(Stroke::new(self.width, Color32::default()))
+        let loop_stroke = Stroke::new(self.width, Color32::default());
+        let shape = EdgeShapeBuilder::new(loop_stroke)
             .looped(node.location(), node_size, self.loop_size, self.order)
             .build();
 

--- a/src/draw/displays_default/node.rs
+++ b/src/draw/displays_default/node.rs
@@ -69,8 +69,8 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
         let circle_radius = ctx.meta.canvas_to_screen_size(self.radius);
         // Base stroke (currently unused in default impl, but exposed for hook customization)
         let base_stroke = Stroke::default();
-            let stroke = if let Some(hook) = &ctx.style.node_stroke_hook {
-                let style_ref: &egui::Style = &ctx.ctx.style();
+        let stroke = if let Some(hook) = &ctx.style.node_stroke_hook {
+            let style_ref: &egui::Style = &ctx.ctx.style();
             (hook)(
                 self.selected,
                 self.dragged,

--- a/src/draw/displays_default/node.rs
+++ b/src/draw/displays_default/node.rs
@@ -69,9 +69,8 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
         let circle_radius = ctx.meta.canvas_to_screen_size(self.radius);
         // Base stroke (currently unused in default impl, but exposed for hook customization)
         let base_stroke = Stroke::default();
-        let stroke = if let Some(hook) = &ctx.style.node_stroke_hook {
-            // Provide egui global style so user can rely on theme colors.
-            let style_ref: &egui::Style = &*ctx.ctx.style();
+            let stroke = if let Some(hook) = &ctx.style.node_stroke_hook {
+                let style_ref: &egui::Style = &ctx.ctx.style();
             (hook)(
                 self.selected,
                 self.dragged,

--- a/src/draw/displays_default/node.rs
+++ b/src/draw/displays_default/node.rs
@@ -67,11 +67,27 @@ impl<N: Clone, E: Clone, Ty: EdgeType, Ix: IndexType> DisplayNode<N, E, Ty, Ix>
 
         let circle_center = ctx.meta.canvas_to_screen_pos(self.pos);
         let circle_radius = ctx.meta.canvas_to_screen_size(self.radius);
+        // Base stroke (currently unused in default impl, but exposed for hook customization)
+        let base_stroke = Stroke::default();
+        let stroke = if let Some(hook) = &ctx.style.node_stroke_hook {
+            // Provide egui global style so user can rely on theme colors.
+            let style_ref: &egui::Style = &*ctx.ctx.style();
+            (hook)(
+                self.selected,
+                self.dragged,
+                self.color,
+                base_stroke,
+                style_ref,
+            )
+        } else {
+            base_stroke
+        };
+
         let circle_shape = CircleShape {
             center: circle_center,
             radius: circle_radius,
             fill: color,
-            stroke: Stroke::default(),
+            stroke,
         };
         res.push(circle_shape.into());
 

--- a/src/layouts/force_directed/layout.rs
+++ b/src/layouts/force_directed/layout.rs
@@ -365,9 +365,7 @@ mod tests {
         let new_dist = (b - a).length();
         assert!(
             new_dist < start_dist,
-            "Distance should shrink due to attraction ({} < {})",
-            new_dist,
-            start_dist
+            "Distance should shrink due to attraction ({new_dist} < {start_dist})"
         );
     }
 
@@ -406,9 +404,7 @@ mod tests {
         let new_dist = (centre - loc).length();
         assert!(
             new_dist < start_dist,
-            "Node should move closer to centre ({} < {})",
-            new_dist,
-            start_dist
+            "Node should move closer to centre ({new_dist} < {start_dist})"
         );
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -244,6 +244,5 @@ pub type NodeStrokeHook = std::sync::Arc<
 >;
 
 /// Type alias for the edge stroke hook closure to keep type signatures concise.
-pub type EdgeStrokeHook = std::sync::Arc<
-    dyn Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync,
->;
+pub type EdgeStrokeHook =
+    std::sync::Arc<dyn Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync>;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -155,9 +155,41 @@ impl SettingsNavigation {
 }
 
 /// `SettingsStyle` stores settings for the style of the graph.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SettingsStyle {
     pub(crate) labels_always: bool,
+    // Optional user-provided hook to override node stroke (outline) styling.
+    // Signature: (selected, dragged, node_color, current_stroke, egui_style) -> new Stroke
+    pub(crate) node_stroke_hook: Option<
+        std::sync::Arc<
+            dyn Fn(bool, bool, Option<egui::Color32>, egui::Stroke, &egui::Style) -> egui::Stroke
+                + Send
+                + Sync,
+        >,
+    >,
+    // Optional user-provided hook to override edge stroke styling.
+    // Signature: (selected, order, current_stroke, egui_style) -> new Stroke
+    pub(crate) edge_stroke_hook: Option<
+        std::sync::Arc<
+            dyn Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync,
+        >,
+    >,
+}
+
+impl core::fmt::Debug for SettingsStyle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SettingsStyle")
+            .field("labels_always", &self.labels_always)
+            .field(
+                "node_stroke_hook",
+                &self.node_stroke_hook.as_ref().map(|_| "<hook>"),
+            )
+            .field(
+                "edge_stroke_hook",
+                &self.edge_stroke_hook.as_ref().map(|_| "<hook>"),
+            )
+            .finish()
+    }
 }
 
 impl SettingsStyle {
@@ -175,6 +207,41 @@ impl SettingsStyle {
     /// Default is false.
     pub fn with_labels_always(mut self, always: bool) -> Self {
         self.labels_always = always;
+        self
+    }
+
+    /// Provide a hook to customize node stroke (outline) styling.
+    /// The hook receives: (selected, dragged, node_color, current_stroke, egui_style) and should return a new Stroke.
+    /// Example:
+    /// ```
+    /// use egui_graphs::SettingsStyle;
+    /// use egui::{Stroke, Color32};
+    /// let style = SettingsStyle::new().with_node_stroke_hook(|selected, _dragged, color, stroke, egui_style| {
+    ///     let mut s = stroke;
+    ///     // Base color from node or egui visuals
+    ///     s.color = color.unwrap_or(egui_style.visuals.widgets.inactive.fg_stroke.color);
+    ///     if selected { s.width = 3.0; }
+    ///     s
+    /// });
+    /// ```
+    pub fn with_node_stroke_hook<F>(mut self, f: F) -> Self
+    where
+        F: Fn(bool, bool, Option<egui::Color32>, egui::Stroke, &egui::Style) -> egui::Stroke
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.node_stroke_hook = Some(std::sync::Arc::new(f));
+        self
+    }
+
+    /// Provide a hook to customize edge stroke styling.
+    /// The hook receives: (selected, order, current_stroke, egui_style) and should return a new Stroke.
+    pub fn with_edge_stroke_hook<F>(mut self, f: F) -> Self
+    where
+        F: Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync + 'static,
+    {
+        self.edge_stroke_hook = Some(std::sync::Arc::new(f));
         self
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -159,21 +159,11 @@ impl SettingsNavigation {
 pub struct SettingsStyle {
     pub(crate) labels_always: bool,
     // Optional user-provided hook to override node stroke (outline) styling.
-    // Signature: (selected, dragged, node_color, current_stroke, egui_style) -> new Stroke
-    pub(crate) node_stroke_hook: Option<
-        std::sync::Arc<
-            dyn Fn(bool, bool, Option<egui::Color32>, egui::Stroke, &egui::Style) -> egui::Stroke
-                + Send
-                + Sync,
-        >,
-    >,
+    // Signature: `(selected, dragged, node_color, current_stroke, egui_style) -> new Stroke`.
+    pub(crate) node_stroke_hook: Option<NodeStrokeHook>,
     // Optional user-provided hook to override edge stroke styling.
-    // Signature: (selected, order, current_stroke, egui_style) -> new Stroke
-    pub(crate) edge_stroke_hook: Option<
-        std::sync::Arc<
-            dyn Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync,
-        >,
-    >,
+    // Signature: `(selected, order, current_stroke, egui_style) -> new Stroke`.
+    pub(crate) edge_stroke_hook: Option<EdgeStrokeHook>,
 }
 
 impl core::fmt::Debug for SettingsStyle {
@@ -211,14 +201,14 @@ impl SettingsStyle {
     }
 
     /// Provide a hook to customize node stroke (outline) styling.
-    /// The hook receives: (selected, dragged, node_color, current_stroke, egui_style) and should return a new Stroke.
+    /// The hook receives: `(selected, dragged, node_color, current_stroke, egui_style)` and should return a new `Stroke`.
     /// Example:
     /// ```
     /// use egui_graphs::SettingsStyle;
     /// use egui::{Stroke, Color32};
     /// let style = SettingsStyle::new().with_node_stroke_hook(|selected, _dragged, color, stroke, egui_style| {
     ///     let mut s = stroke;
-    ///     // Base color from node or egui visuals
+    ///     // Base color from node or `egui` visuals
     ///     s.color = color.unwrap_or(egui_style.visuals.widgets.inactive.fg_stroke.color);
     ///     if selected { s.width = 3.0; }
     ///     s
@@ -236,7 +226,7 @@ impl SettingsStyle {
     }
 
     /// Provide a hook to customize edge stroke styling.
-    /// The hook receives: (selected, order, current_stroke, egui_style) and should return a new Stroke.
+    /// The hook receives: `(selected, order, current_stroke, egui_style)` and should return a new `Stroke`.
     pub fn with_edge_stroke_hook<F>(mut self, f: F) -> Self
     where
         F: Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync + 'static,
@@ -245,3 +235,15 @@ impl SettingsStyle {
         self
     }
 }
+
+/// Type alias for the node stroke hook closure to keep type signatures concise.
+pub type NodeStrokeHook = std::sync::Arc<
+    dyn Fn(bool, bool, Option<egui::Color32>, egui::Stroke, &egui::Style) -> egui::Stroke
+        + Send
+        + Sync,
+>;
+
+/// Type alias for the edge stroke hook closure to keep type signatures concise.
+pub type EdgeStrokeHook = std::sync::Arc<
+    dyn Fn(bool, usize, egui::Stroke, &egui::Style) -> egui::Stroke + Send + Sync,
+>;


### PR DESCRIPTION
- Added stroke customization hooks: SettingsStyle::with_node_stroke_hook, with_edge_stroke_hook.
- DefaultNodeShape / DefaultEdgeShape now apply hooks (no behavior change if unset).
- Demo: theme toggle (sun/moon) in Style panel; edge fade example via hook.
- Demo: added -10 / -1 / +1 / +10 buttons for node & edge counts.
- Demo: transparent, frameless debug overlay with adaptive text color.
- README: added styling hooks section + concise hooks vs custom drawer comparison.
- Internal: custom Debug for SettingsStyle to allow non-Debug closures.

### minor

- Added type aliases for stroke hooks (NodeStrokeHook, EdgeStrokeHook) reducing type complexity.
- Fixed clippy pedantic lints (doc_markdown, uninlined_format_args, explicit_auto_deref, assigning_clones, match_bool, single_match_else, default_trait_access, cast_lossless, comparison_chain, semicolon_if_nothing_returned, unused_self).
- Refactored examples (demo, animated_nodes, flex_nodes, label_change) for lint compliance: safe delta calc, removed risky casts, replaced boolean matches with if/else, used clone_from, clarified asserts, added missing semicolon.
- Simplified demo edge fade hook (alpha reduction) and cleaned extraneous comments.
- Consolidated debug overlay formatting with inline format args.
- Ensured all examples and library pass [cargo clippy --all-targets -D warnings](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Solves #230 