### PR TITLE
Feature gate rand dependency

### DIFF
--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          # Minimal set for bevy / wgpu builds (audio, input, windowing, pkg-config)
+          sudo apt-get install -y --no-install-recommends \
+            libasound2-dev \
+            libudev-dev \
+            pkg-config \
+            libwayland-dev \
+            libxkbcommon-dev \
+            libxcb-composite0-dev \
+            libgtk-3-dev
+
+      - name: cargo build
+        run: cargo build --no-default-features
+
+      - name: cargo test
+        run: cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui", "visualization"]
 egui = { version = "0.32", default-features = false, features = [
   "persistence",
 ] }
-rand = "0.9"
+rand = {version = "0.9", optional = true }
 petgraph = { version = "0.8", default-features = false, features = [
   "graphmap",
   "stable_graph",
@@ -26,7 +26,9 @@ serde = { version = "1.0", features = ["derive"] }
 crossbeam = { version = "0.8", optional = true }
 
 [features]
+# default = ["rand"]
 events = ["dep:crossbeam"]
+rand = ["dep:rand"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/graph_view.rs
+++ b/src/graph_view.rs
@@ -24,8 +24,8 @@ pub type DefaultGraphView<'a> = GraphView<
     DefaultIx,
     DefaultNodeShape,
     DefaultEdgeShape,
-    layouts::random::State,
-    layouts::random::Random,
+    layouts::force_directed::State,
+    layouts::force_directed::ForceDirected,
 >;
 
 #[cfg(feature = "events")]
@@ -60,8 +60,8 @@ pub struct GraphView<
     Ix = DefaultIx,
     Nd = DefaultNodeShape,
     Ed = DefaultEdgeShape,
-    S = layouts::random::State,
-    L = layouts::random::Random,
+    S = layouts::force_directed::State,
+    L = layouts::force_directed::ForceDirected,
 > where
     N: Clone,
     E: Clone,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,6 +6,7 @@ use petgraph::{
     visit::IntoNodeReferences,
     Directed, EdgeType, Undirected,
 };
+#[cfg(feature = "rand")]
 use rand::Rng;
 use std::collections::HashMap;
 
@@ -246,6 +247,7 @@ pub fn default_node_transform<
 }
 
 /// Generates a random graph with the specified number of nodes and edges.
+#[cfg(feature = "rand")]
 pub fn generate_random_graph(num_nodes: usize, num_edges: usize) -> Graph {
     let mut rng = rand::rng();
     let mut graph = StableGraph::new();

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -1,5 +1,6 @@
 pub mod force_directed;
 pub mod hierarchical;
+#[cfg(feature = "rand")]
 pub mod random;
 
 mod layout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@ pub use graph_view::{DefaultGraphView, GraphView};
 #[allow(deprecated)]
 pub use helpers::{
     add_edge, add_edge_custom, add_node, add_node_custom, default_edge_transform,
-    default_node_transform, generate_random_graph, generate_simple_digraph,
+    default_node_transform, generate_simple_digraph,
     generate_simple_ungraph, node_size, to_graph, to_graph_custom,
 };
+
+#[cfg(feature = "rand")]
+pub use helpers::generate_random_graph;
 
 pub use layouts::force_directed::{
     ForceDirected as LayoutForceDirected, State as LayoutStateForceDirected,
@@ -24,6 +27,7 @@ pub use layouts::force_directed::{
 pub use layouts::hierarchical::{
     Hierarchical as LayoutHierarchical, State as LayoutStateHierarchical,
 };
+#[cfg(feature = "rand")]
 pub use layouts::random::{Random as LayoutRandom, State as LayoutStateRandom};
 pub use layouts::{Layout, LayoutState};
 pub use metadata::Metadata;


### PR DESCRIPTION
I want to use `egui_graphs` in a multi-platform project, but have issues compiling it for the WASM target. There are ways around that, but since I do not use the random layout, it may be easier to simply just skip it. (Also, I have not managed to get the workarounds operational.)

This can probably also be beneficial for less dependencies etc.

I added a separate work flow for the tests. Let me know if this should be done in some other way.

(Will convert back from draft once it is working locally. Had problems testing initially.)