### PR TITLE
Cleanup: Expose force with Extras wrapper and modify README

### DIFF
--- a/src/layouts/force_directed/implementations/fruchterman_reingold/with_extras.rs
+++ b/src/layouts/force_directed/implementations/fruchterman_reingold/with_extras.rs
@@ -14,21 +14,21 @@ use crate::layouts::LayoutState;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(bound(serialize = "E: Serialize", deserialize = "E: DeserializeOwned"))]
-pub struct FRWithExtrasState<E: ExtrasTuple> {
+pub struct FruchtermanReingoldWithExtrasState<E: ExtrasTuple> {
     pub base: FruchtermanReingoldState,
     pub extras: E,
 }
-impl<E: ExtrasTuple> LayoutState for FRWithExtrasState<E> {}
+impl<E: ExtrasTuple> LayoutState for FruchtermanReingoldWithExtrasState<E> {}
 
 #[derive(Debug, Default)]
-pub struct FRWithExtras<E: ExtrasTuple> {
-    state: FRWithExtrasState<E>,
+pub struct FruchtermanReingoldWithExtras<E: ExtrasTuple> {
+    state: FruchtermanReingoldWithExtrasState<E>,
     // Reusable displacement buffer
     scratch_disp: Vec<Vec2>,
 }
 
-impl<E: ExtrasTuple> FRWithExtras<E> {
-    pub fn from_state(state: FRWithExtrasState<E>) -> Self {
+impl<E: ExtrasTuple> FruchtermanReingoldWithExtras<E> {
+    pub fn from_state(state: FruchtermanReingoldWithExtrasState<E>) -> Self {
         Self {
             state,
             scratch_disp: Vec::new(),
@@ -36,8 +36,8 @@ impl<E: ExtrasTuple> FRWithExtras<E> {
     }
 }
 
-impl<E: ExtrasTuple> ForceAlgorithm for FRWithExtras<E> {
-    type State = FRWithExtrasState<E>;
+impl<E: ExtrasTuple> ForceAlgorithm for FruchtermanReingoldWithExtras<E> {
+    type State = FruchtermanReingoldWithExtrasState<E>;
 
     fn from_state(state: Self::State) -> Self {
         Self {
@@ -108,6 +108,7 @@ impl<E: ExtrasTuple> ForceAlgorithm for FRWithExtras<E> {
 }
 
 /// Convenience aliases when only center gravity is desired.
-pub type FruchtermanReingoldWithCenterGravity = FRWithExtras<(Extra<CenterGravity, true>, ())>;
+pub type FruchtermanReingoldWithCenterGravity =
+    FruchtermanReingoldWithExtras<(Extra<CenterGravity, true>, ())>;
 pub type FruchtermanReingoldWithCenterGravityState =
-    FRWithExtrasState<(Extra<CenterGravity, true>, ())>;
+    FruchtermanReingoldWithExtrasState<(Extra<CenterGravity, true>, ())>;

--- a/src/layouts/force_directed/mod.rs
+++ b/src/layouts/force_directed/mod.rs
@@ -8,6 +8,7 @@ pub use algorithm::ForceAlgorithm;
 pub use extras::{CenterGravity, CenterGravityParams, Extra};
 pub use implementations::fruchterman_reingold::with_extras::{
     FruchtermanReingoldWithCenterGravity, FruchtermanReingoldWithCenterGravityState,
+    FruchtermanReingoldWithExtras, FruchtermanReingoldWithExtrasState,
 };
 pub use implementations::fruchterman_reingold::{FruchtermanReingold, FruchtermanReingoldState};
 pub use layout::ForceDirected;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use layouts::force_directed::{
     CenterGravity, CenterGravityParams, Extra, ForceAlgorithm,
     ForceDirected as LayoutForceDirected, FruchtermanReingold, FruchtermanReingoldState,
     FruchtermanReingoldWithCenterGravity, FruchtermanReingoldWithCenterGravityState,
+    FruchtermanReingoldWithExtras, FruchtermanReingoldWithExtrasState,
 };
 pub use layouts::hierarchical::{
     Hierarchical as LayoutHierarchical, State as LayoutStateHierarchical,


### PR DESCRIPTION
- expose wrapper for Fruchterman Reingold - `FruchtermanReingoldWithExtras` `FruchtermanReingoldWithExtrasState` for user to be able to add modification for Fruchterman Reingold force
- update readme to reflect usage and customization of forces