### PR TITLE
Feature: custom egui ids

### DIFF
--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -1474,7 +1474,7 @@ impl App for DemoApp {
             // 1) Pan to graph center without changing zoom
             if self.pan_to_graph_pending {
                 // TODO: do we need to interact with metadata explicitly here
-                let mut meta = egui_graphs::Metadata::new(None).load(ui);
+                let mut meta = egui_graphs::MetadataFrame::new(None).load(ui);
                 let bounds = match &self.g {
                     DemoGraph::Directed(g) => g.bounds(),
                     DemoGraph::Undirected(g) => g.bounds(),

--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -733,7 +733,8 @@ impl DemoApp {
     }
 
     pub fn ui_layout_force_directed(&mut self, ui: &mut Ui) {
-        let state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
+        let state =
+            egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
 
         egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, state, None);
     }
@@ -1344,7 +1345,9 @@ impl App for DemoApp {
             match (&mut self.g, self.selected_layout) {
                 (DemoGraph::Directed(ref mut g), DemoLayout::FruchtermanReingold) => {
                     if let Some(spec::PendingLayout::FR(st)) = self.pending_layout.take() {
-                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, st, None);
+                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(
+                            ui, st, None,
+                        );
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1374,7 +1377,9 @@ impl App for DemoApp {
                 }
                 (DemoGraph::Undirected(ref mut g), DemoLayout::FruchtermanReingold) => {
                     if let Some(spec::PendingLayout::FR(st)) = self.pending_layout.take() {
-                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, st, None);
+                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(
+                            ui, st, None,
+                        );
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1495,11 +1500,15 @@ impl App for DemoApp {
             if let DemoLayout::FruchtermanReingold = self.selected_layout {
                 let steps = match &self.g {
                     DemoGraph::Directed(_) => {
-                        let st = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
+                        let st = egui_graphs::get_layout_state::<
+                            FruchtermanReingoldWithCenterGravityState,
+                        >(ui, None);
                         st.base.step_count as usize
                     }
                     DemoGraph::Undirected(_) => {
-                        let st = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
+                        let st = egui_graphs::get_layout_state::<
+                            FruchtermanReingoldWithCenterGravityState,
+                        >(ui, None);
                         st.base.step_count as usize
                     }
                 };

--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -447,47 +447,8 @@ impl DemoApp {
         );
         Self::distribute_nodes_circle_generic(&mut g);
         self.g = DemoGraph::Directed(g);
-        // Reset layout caches for both directed and undirected specializations
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            FruchtermanReingoldWithCenterGravityState,
-            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-        >::reset(ui);
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Undirected,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            FruchtermanReingoldWithCenterGravityState,
-            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-        >::reset(ui);
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            LayoutStateHierarchical,
-            LayoutHierarchical,
-        >::reset(ui);
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Undirected,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            LayoutStateHierarchical,
-            LayoutHierarchical,
-        >::reset(ui);
+        egui_graphs::reset::<FruchtermanReingoldWithCenterGravityState>(ui, None);
+        egui_graphs::reset::<LayoutStateHierarchical>(ui, None);
         ui.ctx().set_visuals(egui::Visuals::dark());
         self.dark_mode = ui.ctx().style().visuals.dark_mode;
         #[cfg(feature = "events")]
@@ -572,17 +533,9 @@ impl DemoApp {
 
                 // If switched to Hierarchical, ensure it recomputes once with current params
                 if changed && matches!(self.selected_layout, DemoLayout::Hierarchical) {
-                    let mut st = egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        LayoutStateHierarchical, LayoutHierarchical,
-                    >::get_layout_state(ui);
+                    let mut st = egui_graphs::get_layout_state::<LayoutStateHierarchical>(ui, None);
                     st.triggered = false;
-                    egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        LayoutStateHierarchical, LayoutHierarchical,
-                    >::set_layout_state(ui, st);
+                    egui_graphs::set_layout_state::<LayoutStateHierarchical>(ui, st, None);
                 }
             });
 
@@ -590,12 +543,7 @@ impl DemoApp {
             // Inline settings for the selected layout
             match self.selected_layout {
                 DemoLayout::FruchtermanReingold => {
-                    let mut state = egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        FruchtermanReingoldWithCenterGravityState,
-                        LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                    >::get_layout_state(ui);
+                    let mut state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
 
                     // Animation section
                     CollapsingHeader::new("Animation").default_open(true).show(ui, |ui| {
@@ -635,13 +583,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_force_run(ui, g, 100);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_force_run(ui, g, 100, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                     DemoGraph::Undirected(g) => {
                                         egui_graphs::GraphView::<
@@ -649,13 +592,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_force_run(ui, g, 100);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Undirected, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_force_run(ui, g, 100, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                 }
                             }
@@ -667,13 +605,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_budgeted_force_run(ui, g, 1000, 100);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_budgeted_force_run(ui, g, 1000, 100, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                     DemoGraph::Undirected(g) => {
                                         let _ = egui_graphs::GraphView::<
@@ -681,13 +614,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_budgeted_force_run(ui, g, 1000, 100);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Undirected, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_budgeted_force_run(ui, g, 1000, 100, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                 }
                             }
@@ -699,13 +627,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_until_stable_force_run(ui, g, 0.01, 1000);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_until_stable_force_run(ui, g, 0.01, 1000, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                     DemoGraph::Undirected(g) => {
                                         let _ = egui_graphs::GraphView::<
@@ -713,13 +636,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_until_stable_force_run(ui, g, 0.01, 1000);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Undirected, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_until_stable_force_run(ui, g, 0.01, 1000, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                 }
                             }
@@ -731,13 +649,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_until_stable_budgeted_force_run(ui, g, 0.01, 10000, 1000);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_until_stable_budgeted_force_run(ui, g, 0.01, 10000, 1000, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                     DemoGraph::Undirected(g) => {
                                         let _ = egui_graphs::GraphView::<
@@ -745,13 +658,8 @@ impl DemoApp {
                                             egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
                                             FruchtermanReingoldWithCenterGravityState,
                                             LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::fast_forward_until_stable_budgeted_force_run(ui, g, 0.01, 10000, 1000);
-                                        state = egui_graphs::GraphView::<
-                                            (), (), petgraph::Undirected, petgraph::stable_graph::DefaultIx,
-                                            egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                                            FruchtermanReingoldWithCenterGravityState,
-                                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                                        >::get_layout_state(ui);
+                                        >::fast_forward_until_stable_budgeted_force_run(ui, g, 0.01, 10000, 1000, None);
+                                        state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                                     }
                                 }
                             }
@@ -790,19 +698,10 @@ impl DemoApp {
                         });
                     });
 
-                    egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        FruchtermanReingoldWithCenterGravityState,
-                        LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                    >::set_layout_state(ui, state);
+                    egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, state, None);
                 }
                 DemoLayout::Hierarchical => {
-                    let mut state = egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        LayoutStateHierarchical, LayoutHierarchical,
-                    >::get_layout_state(ui);
+                    let mut state = egui_graphs::get_layout_state::<LayoutStateHierarchical>(ui, None);
 
                     ui.horizontal(|ui| {
                         ui.add(egui::Slider::new(&mut state.row_dist, 10.0..=500.0).text("row_dist"));
@@ -827,51 +726,20 @@ impl DemoApp {
                         info_icon(ui, "Apply updated parameters and recompute positions once.");
                     });
 
-                    egui_graphs::GraphView::<
-                        (), (), petgraph::Directed, petgraph::stable_graph::DefaultIx,
-                        egui_graphs::DefaultNodeShape, egui_graphs::DefaultEdgeShape,
-                        LayoutStateHierarchical, LayoutHierarchical,
-                    >::set_layout_state(ui, state);
+                    egui_graphs::set_layout_state::<LayoutStateHierarchical>(ui, state, None);
                 }
             }
         });
     }
 
     pub fn ui_layout_force_directed(&mut self, ui: &mut Ui) {
-        let state = egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            FruchtermanReingoldWithCenterGravityState,
-            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-        >::get_layout_state(ui);
+        let state = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
 
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            FruchtermanReingoldWithCenterGravityState,
-            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-        >::set_layout_state(ui, state);
+        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, state, None);
     }
 
     pub fn ui_layout_hierarchical(&mut self, ui: &mut Ui) {
-        let mut state = egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            LayoutStateHierarchical,
-            LayoutHierarchical,
-        >::get_layout_state(ui);
+        let mut state = egui_graphs::get_layout_state::<LayoutStateHierarchical>(ui, None);
 
         CollapsingHeader::new("Hierarchical Layout")
             .default_open(true)
@@ -924,16 +792,7 @@ impl DemoApp {
                 });
             });
 
-        egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            LayoutStateHierarchical,
-            LayoutHierarchical,
-        >::set_layout_state(ui, state);
+        egui_graphs::set_layout_state::<LayoutStateHierarchical>(ui, state, None);
     }
 
     pub fn ui_interaction(&mut self, ui: &mut Ui) {
@@ -1485,18 +1344,7 @@ impl App for DemoApp {
             match (&mut self.g, self.selected_layout) {
                 (DemoGraph::Directed(ref mut g), DemoLayout::FruchtermanReingold) => {
                     if let Some(spec::PendingLayout::FR(st)) = self.pending_layout.take() {
-                        egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Directed,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            egui_graphs::FruchtermanReingoldWithCenterGravityState,
-                            egui_graphs::LayoutForceDirected<
-                                egui_graphs::FruchtermanReingoldWithCenterGravity,
-                            >,
-                        >::set_layout_state(ui, st);
+                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, st, None);
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1526,18 +1374,7 @@ impl App for DemoApp {
                 }
                 (DemoGraph::Undirected(ref mut g), DemoLayout::FruchtermanReingold) => {
                     if let Some(spec::PendingLayout::FR(st)) = self.pending_layout.take() {
-                        egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Undirected,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            egui_graphs::FruchtermanReingoldWithCenterGravityState,
-                            egui_graphs::LayoutForceDirected<
-                                egui_graphs::FruchtermanReingoldWithCenterGravity,
-                            >,
-                        >::set_layout_state(ui, st);
+                        egui_graphs::set_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, st, None);
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1567,16 +1404,7 @@ impl App for DemoApp {
                 }
                 (DemoGraph::Directed(ref mut g), DemoLayout::Hierarchical) => {
                     if let Some(spec::PendingLayout::Hier(st)) = self.pending_layout.take() {
-                        egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Directed,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            egui_graphs::LayoutStateHierarchical,
-                            egui_graphs::LayoutHierarchical,
-                        >::set_layout_state(ui, st);
+                        egui_graphs::set_layout_state::<LayoutStateHierarchical>(ui, st, None);
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1606,16 +1434,7 @@ impl App for DemoApp {
                 }
                 (DemoGraph::Undirected(ref mut g), DemoLayout::Hierarchical) => {
                     if let Some(spec::PendingLayout::Hier(st)) = self.pending_layout.take() {
-                        egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Undirected,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            egui_graphs::LayoutStateHierarchical,
-                            egui_graphs::LayoutHierarchical,
-                        >::set_layout_state(ui, st);
+                        egui_graphs::set_layout_state::<LayoutStateHierarchical>(ui, st, None);
                     }
                     let mut view = egui_graphs::GraphView::<
                         _,
@@ -1650,7 +1469,7 @@ impl App for DemoApp {
             // 1) Pan to graph center without changing zoom
             if self.pan_to_graph_pending {
                 // TODO: do we need to interact with metadata explicitly here
-                let mut meta = egui_graphs::Metadata::new(Some("".to_string())).load(ui);
+                let mut meta = egui_graphs::Metadata::new("".to_string()).load(ui);
                 let bounds = match &self.g {
                     DemoGraph::Directed(g) => g.bounds(),
                     DemoGraph::Undirected(g) => g.bounds(),
@@ -1676,29 +1495,11 @@ impl App for DemoApp {
             if let DemoLayout::FruchtermanReingold = self.selected_layout {
                 let steps = match &self.g {
                     DemoGraph::Directed(_) => {
-                        let st = egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Directed,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            FruchtermanReingoldWithCenterGravityState,
-                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                        >::get_layout_state(ui);
+                        let st = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                         st.base.step_count as usize
                     }
                     DemoGraph::Undirected(_) => {
-                        let st = egui_graphs::GraphView::<
-                            (),
-                            (),
-                            petgraph::Undirected,
-                            petgraph::stable_graph::DefaultIx,
-                            egui_graphs::DefaultNodeShape,
-                            egui_graphs::DefaultEdgeShape,
-                            FruchtermanReingoldWithCenterGravityState,
-                            LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-                        >::get_layout_state(ui);
+                        let st = egui_graphs::get_layout_state::<FruchtermanReingoldWithCenterGravityState>(ui, None);
                         st.base.step_count as usize
                     }
                 };
@@ -1805,46 +1606,10 @@ impl DemoApp {
     fn record_perf_sample(&mut self, ui: &mut egui::Ui) {
         let route = pick_metrics_route(&self.g, self.selected_layout);
         let (step_ms, draw_ms) = match route {
-            MetricsRoute::DirectedFR => egui_graphs::GraphView::<
-                (),
-                (),
-                petgraph::Directed,
-                petgraph::stable_graph::DefaultIx,
-                egui_graphs::DefaultNodeShape,
-                egui_graphs::DefaultEdgeShape,
-                FruchtermanReingoldWithCenterGravityState,
-                LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-            >::get_metrics(ui),
-            MetricsRoute::UndirectedFR => egui_graphs::GraphView::<
-                (),
-                (),
-                petgraph::Undirected,
-                petgraph::stable_graph::DefaultIx,
-                egui_graphs::DefaultNodeShape,
-                egui_graphs::DefaultEdgeShape,
-                FruchtermanReingoldWithCenterGravityState,
-                LayoutForceDirected<FruchtermanReingoldWithCenterGravity>,
-            >::get_metrics(ui),
-            MetricsRoute::DirectedHier => egui_graphs::GraphView::<
-                (),
-                (),
-                petgraph::Directed,
-                petgraph::stable_graph::DefaultIx,
-                egui_graphs::DefaultNodeShape,
-                egui_graphs::DefaultEdgeShape,
-                LayoutStateHierarchical,
-                LayoutHierarchical,
-            >::get_metrics(ui),
-            MetricsRoute::UndirectedHier => egui_graphs::GraphView::<
-                (),
-                (),
-                petgraph::Undirected,
-                petgraph::stable_graph::DefaultIx,
-                egui_graphs::DefaultNodeShape,
-                egui_graphs::DefaultEdgeShape,
-                LayoutStateHierarchical,
-                LayoutHierarchical,
-            >::get_metrics(ui),
+            MetricsRoute::DirectedFR => egui_graphs::get_metrics(ui, None),
+            MetricsRoute::UndirectedFR => egui_graphs::get_metrics(ui, None),
+            MetricsRoute::DirectedHier => egui_graphs::get_metrics(ui, None),
+            MetricsRoute::UndirectedHier => egui_graphs::get_metrics(ui, None),
         };
 
         self.metrics.record_sample(step_ms, draw_ms);

--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -1474,7 +1474,7 @@ impl App for DemoApp {
             // 1) Pan to graph center without changing zoom
             if self.pan_to_graph_pending {
                 // TODO: do we need to interact with metadata explicitly here
-                let mut meta = egui_graphs::Metadata::new("".to_string()).load(ui);
+                let mut meta = egui_graphs::Metadata::new(None).load(ui);
                 let bounds = match &self.g {
                     DemoGraph::Directed(g) => g.bounds(),
                     DemoGraph::Undirected(g) => g.bounds(),

--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -1646,9 +1646,11 @@ impl App for DemoApp {
             }
 
             // After rendering the view, handle pending one-shot navigation actions.
+
             // 1) Pan to graph center without changing zoom
             if self.pan_to_graph_pending {
-                let mut meta = egui_graphs::Metadata::load(ui);
+                // TODO: do we need to interact with metadata explicitly here
+                let mut meta = egui_graphs::Metadata::new(Some("".to_string())).load(ui);
                 let bounds = match &self.g {
                     DemoGraph::Directed(g) => g.bounds(),
                     DemoGraph::Undirected(g) => g.bounds(),
@@ -1660,6 +1662,7 @@ impl App for DemoApp {
                 self.pan_to_graph_pending = false;
                 self.notify_info("Fit to screen (no zoom)");
             }
+
             // 2) Fit to screen once: turn off the auto-fit after it has just been applied.
             if self.fit_to_screen_once_pending && self.settings_navigation.fit_to_screen_enabled {
                 self.settings_navigation.fit_to_screen_enabled = false;

--- a/crates/demo-core/src/spec.rs
+++ b/crates/demo-core/src/spec.rs
@@ -187,16 +187,9 @@ impl LayoutSpec {
 // Export helpers (demo-only): read current UI layout state and build LayoutSpec
 impl PendingLayout {
     pub fn from_ui_fr_state(ui: &mut egui::Ui) -> LayoutSpec {
-        let st = egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
+        let st = egui_graphs::get_layout_state::<
             egui_graphs::FruchtermanReingoldWithCenterGravityState,
-            egui_graphs::LayoutForceDirected<egui_graphs::FruchtermanReingoldWithCenterGravity>,
-        >::get_layout_state(ui);
+        >(ui, None);
         LayoutSpec::FruchtermanReingold {
             running: Some(st.base.is_running),
             dt: Some(st.base.dt),
@@ -214,16 +207,7 @@ impl PendingLayout {
     }
 
     pub fn from_ui_hier_state(ui: &mut egui::Ui) -> LayoutSpec {
-        let st = egui_graphs::GraphView::<
-            (),
-            (),
-            petgraph::Directed,
-            petgraph::stable_graph::DefaultIx,
-            egui_graphs::DefaultNodeShape,
-            egui_graphs::DefaultEdgeShape,
-            egui_graphs::LayoutStateHierarchical,
-            egui_graphs::LayoutHierarchical,
-        >::get_layout_state(ui);
+        let st = egui_graphs::get_layout_state::<egui_graphs::LayoutStateHierarchical>(ui, None);
         LayoutSpec::Hierarchical {
             row_dist: Some(st.row_dist),
             col_dist: Some(st.col_dist),

--- a/crates/egui_graphs/examples/flex_nodes.rs
+++ b/crates/egui_graphs/examples/flex_nodes.rs
@@ -104,7 +104,7 @@ impl FlexNodesApp {
             selected_edge: Option::default(),
         };
 
-        DefaultGraphView::reset(ui);
+        egui_graphs::reset::<egui_graphs::LayoutStateRandom>(ui, None);
     }
 }
 

--- a/crates/egui_graphs/examples/label_change.rs
+++ b/crates/egui_graphs/examples/label_change.rs
@@ -104,7 +104,7 @@ impl LabelChangeApp {
             selected_edge: Option::default(),
         };
 
-        DefaultGraphView::reset(ui);
+        egui_graphs::reset::<egui_graphs::LayoutStateRandom>(ui, None);
     }
 }
 

--- a/crates/egui_graphs/examples/multiple.rs
+++ b/crates/egui_graphs/examples/multiple.rs
@@ -1,34 +1,56 @@
+// FIXME: when small screen width, the graph slow to respond to drag
+// TODO: check that multiple views with same id work as expected (set custom zoom and pan and check sync)
+
 use eframe::{run_native, App, CreationContext, Frame};
 use egui::{CentralPanel, Context, Layout, SidePanel};
 use egui_graphs::{generate_simple_digraph, DefaultGraphView, Graph};
 
 pub struct BasicApp {
-    g: Graph,
+    g1: Graph,
+    g2: Graph,
+    g3: Graph,
 }
 
 impl BasicApp {
     fn new(_: &CreationContext<'_>) -> Self {
-        let g = generate_simple_digraph();
-        Self { g: Graph::from(&g) }
+        let g1 = generate_simple_digraph();
+        let g2 = generate_simple_digraph();
+        let g3 = generate_simple_digraph();
+        Self {
+            g1: Graph::from(&g1),
+            g2: Graph::from(&g2),
+            g3: Graph::from(&g3),
+        }
     }
 }
 
 impl App for BasicApp {
     fn update(&mut self, ctx: &Context, _: &mut Frame) {
+        print!("\n\n============\n");
+        print!("updating frame\n");
+
+        let id1 = Some("id_1".to_string());
+        let id2 = Some("id_2".to_string());
+        let id3 = Some("id_3".to_string());
+
         let available_width = ctx.available_rect().width();
         SidePanel::left("left_panel")
             .default_width(available_width / 3.)
             .resizable(true)
             .show(ctx, |ui| {
                 ui.allocate_ui_with_layout(ui.max_rect().size(), Layout::default(), |ui| {
-                    ui.add(&mut DefaultGraphView::new(&mut self.g));
+                    ui.add(&mut DefaultGraphView::new(&mut self.g1).with_id(id1.clone()));
                 });
             });
         SidePanel::right("right_panel")
             .default_width(available_width / 3.)
             .resizable(true)
-            .show(ctx, |ui| ui.add(&mut DefaultGraphView::new(&mut self.g)));
-        CentralPanel::default().show(ctx, |ui| ui.add(&mut DefaultGraphView::new(&mut self.g)));
+            .show(ctx, |ui| {
+                ui.add(&mut DefaultGraphView::new(&mut self.g1).with_id(id1))
+            });
+        CentralPanel::default().show(ctx, |ui| {
+            ui.add(&mut DefaultGraphView::new(&mut self.g3).with_id(id3))
+        });
     }
 }
 

--- a/crates/egui_graphs/examples/multiple.rs
+++ b/crates/egui_graphs/examples/multiple.rs
@@ -1,5 +1,6 @@
 // FIXME: when small screen width, the graph slow to respond to drag
 // TODO: check that multiple views with same id work as expected (set custom zoom and pan and check sync)
+// FIXME: graph is not visible for id_1, works fine when ids and graphs are different
 
 use eframe::{run_native, App, CreationContext, Frame};
 use egui::{CentralPanel, Context, Layout, SidePanel};
@@ -8,30 +9,23 @@ use egui_graphs::{generate_simple_digraph, DefaultGraphView, Graph};
 pub struct BasicApp {
     g1: Graph,
     g2: Graph,
-    g3: Graph,
 }
 
 impl BasicApp {
     fn new(_: &CreationContext<'_>) -> Self {
         let g1 = generate_simple_digraph();
         let g2 = generate_simple_digraph();
-        let g3 = generate_simple_digraph();
         Self {
             g1: Graph::from(&g1),
             g2: Graph::from(&g2),
-            g3: Graph::from(&g3),
         }
     }
 }
 
 impl App for BasicApp {
     fn update(&mut self, ctx: &Context, _: &mut Frame) {
-        print!("\n\n============\n");
-        print!("updating frame\n");
-
         let id1 = Some("id_1".to_string());
         let id2 = Some("id_2".to_string());
-        let id3 = Some("id_3".to_string());
 
         let available_width = ctx.available_rect().width();
         SidePanel::left("left_panel")
@@ -49,7 +43,7 @@ impl App for BasicApp {
                 ui.add(&mut DefaultGraphView::new(&mut self.g1).with_id(id1))
             });
         CentralPanel::default().show(ctx, |ui| {
-            ui.add(&mut DefaultGraphView::new(&mut self.g3).with_id(id3))
+            ui.add(&mut DefaultGraphView::new(&mut self.g2).with_id(id2))
         });
     }
 }

--- a/crates/egui_graphs/src/draw/displays_default/edge_shape_builder.rs
+++ b/crates/egui_graphs/src/draw/displays_default/edge_shape_builder.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 
 use egui::{epaint::CubicBezierShape, Color32, Pos2, Shape, Stroke, Vec2};
 
-use crate::Metadata;
+use crate::metadata::MetadataFrame;
 
 enum EdgeShapeProps {
     Straight {
@@ -40,7 +40,7 @@ pub struct EdgeShapeBuilder<'a> {
     shape_props: EdgeShapeProps,
     tip: Option<&'a TipProps>,
     stroke: Stroke,
-    scaler: Option<&'a Metadata>,
+    scaler: Option<&'a MetadataFrame>,
 }
 
 impl<'a> EdgeShapeBuilder<'a> {
@@ -84,7 +84,7 @@ impl<'a> EdgeShapeBuilder<'a> {
         self
     }
 
-    pub fn with_scaler(mut self, scaler: &'a Metadata) -> Self {
+    pub fn with_scaler(mut self, scaler: &'a MetadataFrame) -> Self {
         self.scaler = Some(scaler);
 
         self

--- a/crates/egui_graphs/src/draw/drawer.rs
+++ b/crates/egui_graphs/src/draw/drawer.rs
@@ -6,8 +6,9 @@ use petgraph::EdgeType;
 
 use crate::{
     layouts::{Layout, LayoutState},
+    metadata::MetadataFrame,
     settings::SettingsStyle,
-    Graph, Metadata,
+    Graph,
 };
 
 use super::{DisplayEdge, DisplayNode};
@@ -18,7 +19,7 @@ pub struct DrawContext<'a> {
     pub painter: &'a Painter,
     pub style: &'a SettingsStyle,
     pub is_directed: bool,
-    pub meta: &'a Metadata,
+    pub meta: &'a MetadataFrame,
 }
 
 pub(crate) struct Drawer<'a, N, E, Ty, Ix, Nd, Ed, S, L>

--- a/crates/egui_graphs/src/graph.rs
+++ b/crates/egui_graphs/src/graph.rs
@@ -16,7 +16,7 @@ use crate::draw::{DisplayEdge, DisplayNode};
 use crate::{
     default_edge_transform, default_node_transform, to_graph, DefaultEdgeShape, DefaultNodeShape,
 };
-use crate::{metadata::Metadata, Edge, Node};
+use crate::{metadata::MetadataFrame, Edge, Node};
 
 type StableGraphType<N, E, Ty, Ix, Dn, De> =
     StableGraph<Node<N, E, Ty, Ix, Dn>, Edge<N, E, Ty, Ix, Dn, De>, Ty, Ix>;
@@ -84,7 +84,11 @@ where
     }
 
     /// Finds node by position. Can be optimized by using a spatial index like quad-tree if needed.
-    pub fn node_by_screen_pos(&self, meta: &Metadata, screen_pos: Pos2) -> Option<NodeIndex<Ix>> {
+    pub fn node_by_screen_pos(
+        &self,
+        meta: &MetadataFrame,
+        screen_pos: Pos2,
+    ) -> Option<NodeIndex<Ix>> {
         let pos_in_graph = meta.screen_to_canvas_pos(screen_pos);
         for (idx, node) in self.nodes_iter() {
             let display = node.display();
@@ -97,7 +101,11 @@ where
 
     /// Finds edge by position.
     #[allow(clippy::missing_panics_doc)] // TODO: add panics doc
-    pub fn edge_by_screen_pos(&self, meta: &Metadata, screen_pos: Pos2) -> Option<EdgeIndex<Ix>> {
+    pub fn edge_by_screen_pos(
+        &self,
+        meta: &MetadataFrame,
+        screen_pos: Pos2,
+    ) -> Option<EdgeIndex<Ix>> {
         let pos_in_graph = meta.screen_to_canvas_pos(screen_pos);
         for (idx, e) in self.edges_iter() {
             let Some((idx_start, idx_end)) = self.g.edge_endpoints(e.id()) else {

--- a/crates/egui_graphs/src/graph_view.rs
+++ b/crates/egui_graphs/src/graph_view.rs
@@ -244,7 +244,12 @@ where
         self.sync_layout(ui);
         let step_ms = t0.elapsed().as_secs_f32() * 1000.0;
 
-        let mut meta = Metadata::new(self.custom_id.clone().unwrap_or_default()).load(ui);
+        print!(
+            "loading metadata for id: {}\n",
+            self.custom_id.clone().unwrap_or_default()
+        );
+
+        let mut meta = Metadata::new(self.custom_id.clone()).load(ui);
         self.sync_state(&mut meta);
 
         // Compute effective interactions once per frame
@@ -279,6 +284,8 @@ where
         meta.last_draw_time_ms = draw_ms;
 
         meta.first_frame = false;
+
+        print!("saving metadata with id: {}\n", meta.get_key());
         meta.save(ui);
 
         ui.ctx().request_repaint();
@@ -602,15 +609,15 @@ where
     }
 
     fn sync_layout(&mut self, ui: &mut Ui) {
-        let key = self.custom_id.clone().unwrap_or_default();
+        let id = self.custom_id.clone();
 
-        let state = S::load(ui, key.clone());
+        let state = S::load(ui, id.clone());
 
         let mut layout = L::from_state(state);
         layout.next(self.g, ui);
         let new_state = layout.state();
 
-        new_state.save(ui, key);
+        new_state.save(ui, id);
     }
 
     fn sync_state(&mut self, meta: &mut Metadata) {
@@ -1221,24 +1228,21 @@ pub fn reset<S: LayoutState>(ui: &mut Ui, id: Option<String>) {
 
 /// Returns the latest per-frame performance metrics stored in metadata.
 pub fn get_metrics(ui: &egui::Ui, id: Option<String>) -> (f32, f32) {
-    let m = Metadata::new(id.unwrap_or_default()).load(ui);
+    let m = Metadata::new(id).load(ui);
     (m.last_step_time_ms, m.last_draw_time_ms)
 }
 
 /// Resets [`Layout`] state
 pub fn reset_layout<S: LayoutState>(ui: &mut Ui, id: Option<String>) {
-    let key = id.unwrap_or_default();
-    S::default().save(ui, key);
+    S::default().save(ui, id);
 }
 
 /// Loads current persisted layout state (or default if none). Useful for external UI panels.
 pub fn get_layout_state<S: LayoutState>(ui: &egui::Ui, id: Option<String>) -> S {
-    let key = id.unwrap_or_default();
-    S::load(ui, key)
+    S::load(ui, id)
 }
 
 /// Persists a new layout state so that on the next frame it will be applied.
 pub fn set_layout_state<S: LayoutState>(ui: &mut egui::Ui, state: S, id: Option<String>) {
-    let key = id.unwrap_or_default();
-    state.save(ui, key);
+    state.save(ui, id);
 }

--- a/crates/egui_graphs/src/graph_view.rs
+++ b/crates/egui_graphs/src/graph_view.rs
@@ -241,7 +241,10 @@ where
         self.sync_layout(ui);
         let step_ms = t0.elapsed().as_secs_f32() * 1000.0;
 
-        let mut meta = Metadata::load(ui);
+        // TODO: propagate from the outside
+        let custom_key = Some("".to_string());
+
+        let mut meta = Metadata::new(custom_key).load(ui);
         self.sync_state(&mut meta);
 
         // Compute effective interactions once per frame
@@ -477,7 +480,10 @@ where
 
     /// Resets [`Metadata`] state
     pub fn reset_metadata(ui: &mut Ui) {
-        Metadata::default().save(ui);
+        // TODO: propagate from self
+        let custom_key = Some("".to_string());
+
+        Metadata::new(custom_key).save(ui);
     }
 
     /// Resets [`Layout`] state
@@ -497,7 +503,10 @@ where
 
     /// Returns the latest per-frame performance metrics stored in metadata.
     pub fn get_metrics(ui: &egui::Ui) -> (f32, f32) {
-        let m = Metadata::load(ui);
+        // TODO: propagate from the outside
+        let custom_key = Some("".to_string());
+
+        let m = Metadata::new(custom_key).load(ui);
         (m.last_step_time_ms, m.last_draw_time_ms)
     }
 

--- a/crates/egui_graphs/src/layouts/layout.rs
+++ b/crates/egui_graphs/src/layouts/layout.rs
@@ -4,7 +4,25 @@ use std::fmt::Debug;
 
 use crate::{DisplayEdge, DisplayNode, Graph};
 
-pub trait LayoutState: SerializableAny + Default + Debug {}
+const KEY_PREFIX: &str = "egui_graphs_layout";
+fn get_key(key: String) -> String {
+    format!("{KEY_PREFIX}_{key}")
+}
+
+pub trait LayoutState: SerializableAny + Default + Debug {
+    fn load(ui: &egui::Ui, key: String) -> Self {
+        ui.data_mut(|data| {
+            data.get_persisted::<Self>(egui::Id::new(get_key(key)))
+                .unwrap_or_default()
+        })
+    }
+
+    fn save(self, ui: &mut egui::Ui, key: String) {
+        ui.data_mut(|data| {
+            data.insert_persisted(egui::Id::new(get_key(key)), self);
+        });
+    }
+}
 
 /// Optional hooks for animated/simulated layout states.
 /// Implement on your layout state to allow `GraphView` helpers to force-run steps

--- a/crates/egui_graphs/src/layouts/layout.rs
+++ b/crates/egui_graphs/src/layouts/layout.rs
@@ -5,21 +5,21 @@ use std::fmt::Debug;
 use crate::{DisplayEdge, DisplayNode, Graph};
 
 const KEY_PREFIX: &str = "egui_graphs_layout";
-fn get_key(key: String) -> String {
-    format!("{KEY_PREFIX}_{key}")
+fn get_key(id: Option<String>) -> String {
+    format!("{KEY_PREFIX}_{}", id.unwrap_or_default())
 }
 
 pub trait LayoutState: SerializableAny + Default + Debug {
-    fn load(ui: &egui::Ui, key: String) -> Self {
+    fn load(ui: &egui::Ui, id: Option<String>) -> Self {
         ui.data_mut(|data| {
-            data.get_persisted::<Self>(egui::Id::new(get_key(key)))
+            data.get_persisted::<Self>(egui::Id::new(get_key(id)))
                 .unwrap_or_default()
         })
     }
 
-    fn save(self, ui: &mut egui::Ui, key: String) {
+    fn save(self, ui: &mut egui::Ui, id: Option<String>) {
         ui.data_mut(|data| {
-            data.insert_persisted(egui::Id::new(get_key(key)), self);
+            data.insert_persisted(egui::Id::new(get_key(id)), self);
         });
     }
 }

--- a/crates/egui_graphs/src/lib.rs
+++ b/crates/egui_graphs/src/lib.rs
@@ -11,7 +11,8 @@ pub use draw::{DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode, Dra
 pub use elements::{Edge, EdgeProps, Node, NodeProps};
 pub use graph::Graph;
 pub use graph_view::{
-    get_metrics, reset, reset_layout, reset_metadata, set_layout_state, get_layout_state, DefaultGraphView, GraphView,
+    get_layout_state, get_metrics, reset, reset_layout, set_layout_state, DefaultGraphView,
+    GraphView,
 };
 #[allow(deprecated)]
 pub use helpers::{
@@ -32,7 +33,7 @@ pub use layouts::hierarchical::{
 };
 pub use layouts::random::{Random as LayoutRandom, State as LayoutStateRandom};
 pub use layouts::{Layout, LayoutState};
-pub use metadata::Metadata;
+pub use metadata::{reset_metadata, Metadata};
 pub use settings::{SettingsInteraction, SettingsNavigation, SettingsStyle};
 
 #[cfg(feature = "events")]

--- a/crates/egui_graphs/src/lib.rs
+++ b/crates/egui_graphs/src/lib.rs
@@ -33,7 +33,7 @@ pub use layouts::hierarchical::{
 };
 pub use layouts::random::{Random as LayoutRandom, State as LayoutStateRandom};
 pub use layouts::{Layout, LayoutState};
-pub use metadata::{reset_metadata, Metadata};
+pub use metadata::{reset_metadata, MetadataFrame};
 pub use settings::{SettingsInteraction, SettingsNavigation, SettingsStyle};
 
 #[cfg(feature = "events")]

--- a/crates/egui_graphs/src/lib.rs
+++ b/crates/egui_graphs/src/lib.rs
@@ -10,7 +10,9 @@ mod settings;
 pub use draw::{DefaultEdgeShape, DefaultNodeShape, DisplayEdge, DisplayNode, DrawContext};
 pub use elements::{Edge, EdgeProps, Node, NodeProps};
 pub use graph::Graph;
-pub use graph_view::{DefaultGraphView, GraphView};
+pub use graph_view::{
+    get_metrics, reset, reset_layout, reset_metadata, set_layout_state, get_layout_state, DefaultGraphView, GraphView,
+};
 #[allow(deprecated)]
 pub use helpers::{
     add_edge, add_edge_custom, add_node, add_node_custom, default_edge_transform,

--- a/crates/egui_graphs/src/metadata.rs
+++ b/crates/egui_graphs/src/metadata.rs
@@ -1,4 +1,4 @@
-use egui::{Id, Pos2, Rect, Vec2};
+use egui::{Id, Pos2, Rect, Ui, Vec2};
 use petgraph::{stable_graph::IndexType, EdgeType};
 use serde::{Deserialize, Serialize};
 
@@ -162,4 +162,9 @@ impl Metadata {
 
         format!("{KEY_PREFIX}_{custom_key}")
     }
+}
+
+/// Resets [`Metadata`] state
+pub fn reset_metadata(ui: &mut Ui, id: Option<String>) {
+    Metadata::new(id.unwrap_or_default()).save(ui);
 }

--- a/crates/egui_graphs/src/metadata.rs
+++ b/crates/egui_graphs/src/metadata.rs
@@ -65,7 +65,7 @@ pub struct Metadata {
     /// Last measured time to draw the current frame, excluding the layout step (milliseconds)
     pub last_draw_time_ms: f32,
     /// Custom key to identify the metadata
-    custom_key: Option<String>,
+    key: String,
     /// State of bounds iteration
     bounds: Bounds,
 }
@@ -80,15 +80,15 @@ impl Default for Metadata {
             last_step_time_ms: 0.0,
             last_draw_time_ms: 0.0,
             bounds: Bounds::default(),
-            custom_key: None,
+            key: "".to_string(),
         }
     }
 }
 
 impl Metadata {
-    pub fn new(custom_key: Option<String>) -> Self {
+    pub fn new(key: String) -> Self {
         Self {
-            custom_key,
+            key,
             ..Default::default()
         }
     }
@@ -158,7 +158,7 @@ impl Metadata {
     }
 
     fn get_key(&self) -> String {
-        let custom_key = self.custom_key.clone().unwrap_or_default();
+        let custom_key = self.key.clone();
 
         format!("{KEY_PREFIX}_{custom_key}")
     }


### PR DESCRIPTION
This pull request refactors the way layout state and cache management functions are called in the `DemoApp` implementation, moving from verbose, type-heavy invocations to new, more concise helper functions provided by the `egui_graphs` crate. This change simplifies the codebase, improves readability, and reduces the risk of mistakes with complex generic parameters.

Key changes include:

**Refactoring layout state and cache handling:**

- Replaced all usages of the verbose `egui_graphs::GraphView::<...>::get_layout_state`, `::set_layout_state`, and `::reset` calls with the new, simpler `egui_graphs::get_layout_state`, `set_layout_state`, and `reset` helper functions throughout `crates/demo-core/src/lib.rs`. These new functions require only the layout state type and an optional context, making the code easier to read and maintain. 

**Function signature updates:**

- Updated all relevant calls to layout fast-forward and budgeted force run methods to include an additional optional parameter, aligning with the new function signatures in `egui_graphs`. 

**General code simplification:**

- Removed repeated and verbose type annotations, reducing boilerplate and improving clarity in layout management logic. 

These changes make the codebase more maintainable and easier to extend in the future.

Solves #246 