### PR TITLE
Fix: replace 'instant' dependency with 'web-time'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ petgraph = { version = "0.8", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 rand = "0.9"
-instant = { version = "0.1", features = ["wasm-bindgen"] }
+web-time = "1.1"
 crossbeam = "0.8"
 bevy = "0.16"
 bevy_egui = "0.36"

--- a/crates/demo-core/Cargo.toml
+++ b/crates/demo-core/Cargo.toml
@@ -20,7 +20,7 @@ petgraph = { workspace = true, default-features = false, features = [
   "matrix_graph",
 ] }
 rand.workspace = true
-instant.workspace = true
+web-time.workspace = true
 crossbeam = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/demo-core/src/lib.rs
+++ b/crates/demo-core/src/lib.rs
@@ -7,7 +7,7 @@ use egui_graphs::{
     LayoutHierarchicalOrientation, LayoutStateHierarchical,
 };
 #[cfg(not(feature = "events"))]
-use instant::Instant;
+use web_time::Instant;
 use petgraph::stable_graph::{DefaultIx, EdgeIndex, NodeIndex};
 use petgraph::{Directed, Undirected};
 use rand::Rng;

--- a/crates/demo-core/src/metrics.rs
+++ b/crates/demo-core/src/metrics.rs
@@ -1,5 +1,5 @@
 use core::time::Duration;
-use instant::Instant;
+use web_time::Instant;
 use std::collections::VecDeque;
 
 pub struct MetricsRecorder {

--- a/crates/demo-core/src/status.rs
+++ b/crates/demo-core/src/status.rs
@@ -1,4 +1,4 @@
-use instant::Instant;
+use web_time::Instant;
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/egui_graphs/Cargo.toml
+++ b/crates/egui_graphs/Cargo.toml
@@ -22,7 +22,7 @@ petgraph = { workspace = true, default-features = false, features = [
   "serde-1",
 ] }
 serde = { workspace = true, features = ["derive"] }
-instant.workspace = true
+web-time.workspace = true
 
 crossbeam = { workspace = true, optional = true }
 

--- a/crates/egui_graphs/src/graph_view.rs
+++ b/crates/egui_graphs/src/graph_view.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use egui::{Id, PointerButton, Pos2, Rect, Response, Sense, Ui, Vec2, Widget};
-use instant::Instant;
+use web_time::Instant;
 
 use petgraph::{graph::EdgeIndex, stable_graph::DefaultIx};
 use petgraph::{graph::IndexType, Directed};


### PR DESCRIPTION
# The Bug
While using this crate, I encounered an error with my project's wasm build that went something like this:
```
Module not found: Error: Can't resolve 'env' in 'my-project/pkg'
```

# Finding the source
After a little searching, I found this [helpful issue](https://github.com/orgs/community/discussions/16289#discussion-4062908) on the wasm-bindgen repository. I used [this tool]( https://github.com/Liamolucko/find_wasm_import) (mentioned in the issue) on my project to attempt to find the source of the error, and the source was the instant crate.

# Solution
In all regards, web_time seems to be superior to instant. Instant even mentions in [their readme](https://github.com/sebcrozet/instant/blob/master/README.md) that the crate is unmaintained and web_time should be considered as an alternative.